### PR TITLE
Fix PHP 8.x compatibility

### DIFF
--- a/plg_titlelink/titlelink.php
+++ b/plg_titlelink/titlelink.php
@@ -292,7 +292,7 @@ class plgSystemTitleLink extends JPlugin
                         if (!array_key_exists($phrase, $titlelink_cache)) {
                             // try to find an exact match
                             $result = $this->getByPlugins($database, $this->plugin_cache, $phrase, false);
-                            if ((count($result) != 2) && ($partial_match)) {
+                            if ($partial_match && (is_null($result) || (count($result) != 2))) {
                                 // no exact match found --> try partial match
                                 $result = $this->getByPlugins($database, $this->plugin_cache, $phrase, true);
                             }
@@ -302,7 +302,7 @@ class plgSystemTitleLink extends JPlugin
                         }
 
                         // found something? --> save it
-                        if (count($result) == 2) {
+                        if (!is_null($result) && count($result) == 2) {
                             // save result in cache
                             $titlelink_cache[$phrase] = $result;
                             $link = $result[0];
@@ -450,7 +450,7 @@ class plgSystemTitleLink extends JPlugin
                             $link .= "</ul>";
 
                             $link .= "<br />plugin-results:<ul>";
-                            $count = count($result);
+                            $count = is_null($result) ? 0 : count($result);
                             for ($i = 0; $i < $count; $i++) {
                                 $link .= "<li>" . $result[$i] . "</li>";
                             }
@@ -522,7 +522,7 @@ class plgSystemTitleLink extends JPlugin
             $result = call_user_func($plugins[$i], $database, $phrase_escaped, $partial_match);
 
             // magix number '2' is the amount of strings we need as result
-            if ($result != null && count($result) == 2) {
+            if (!is_null($result) && count($result) == 2) {
                 return $result;
             }
         }


### PR DESCRIPTION
Relates to https://github.com/gesellix/titlelink/pull/18#issuecomment-1286988800

Fixes https://github.com/gesellix/titlelink/pull/18#issuecomment-1286524587 or errors like this when running on Joomla 3.x and PHP 8.x:

```
When I open certain (but not all) menus, I get the following error which I did not get before installing the updated version of Titlelink and upgrading to PHP 8.1:

count(): Argument #1 ($value) must be of type Countable|array, null given - 0

Debugging information shows:

JROOT/plugins/system/titlelink/titlelink.php:295
JROOT/plugins/system/titlelink/titlelink.php:120 plgSystemTitleLink->replaceTitleLinksWithURLs()
JROOT/libraries/joomla/event/event.php:70 plgSystemTitleLink->onAfterRender()

It looks like the problem is caused by Titlelink interacting with PHP 8.1...
```

We might use `is_countable()` instead of `is_null()`, but then we would bump our baseline to require PHP 7.3.
