### PR TITLE
fix check for installed com_weblinks in J4 ff

### DIFF
--- a/plg_titlelink/titlelink_plugins/plugin_weblinks.php
+++ b/plg_titlelink/titlelink_plugins/plugin_weblinks.php
@@ -15,7 +15,7 @@ function plugin_weblinks($database, $phrase, $partial_match = true)
 
   $result = null;
 
-  if (file_exists("components/com_weblinks/weblinks.php"))
+  if (is_dir("components/com_weblinks"))
   {
     $where_clause = ($partial_match) ? "LIKE '%$phrase%'" : "= '$phrase'";
 


### PR DESCRIPTION
Resolves #27

In the [weblinks](https://github.com/joomla-extensions/weblinks/) extension used in Joomla 4 and later the file `components/com_weblinks/weblinks.php` does not exist any more, so just check for the directory.
